### PR TITLE
Add feature to enable debugging via URL param

### DIFF
--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -2,7 +2,13 @@
 
 import queue from 'src/utils/queue'
 
+jest.mock('src/utils/getURL')
 jest.mock('src/utils/queue')
+
+beforeEach(() => {
+  const getURL = require('src/utils/getURL').default
+  getURL.mockReturnValue('https://example.com/foo/bar/')
+})
 
 afterEach(() => {
   jest.resetModules()
@@ -81,6 +87,7 @@ describe('config: setConfig', () => {
         domain: 'example.com',
         pageUrl: 'https://example.com/foo',
       },
+      logLevel: 'warn',
     }
     const config = setConfig(modifiedConfig)
     expect(config).toMatchObject({
@@ -97,6 +104,7 @@ describe('config: setConfig', () => {
       },
       newTabAds: expect.any(Object), // default value
       adUnits: expect.any(Array), // default value
+      logLevel: 'warn',
     })
   })
 
@@ -136,6 +144,29 @@ describe('config: setConfig', () => {
     const { setConfig } = require('src/config')
     setConfig(getMinimalValidUserConfig())
     expect(queue.runQueue).toHaveBeenCalledWith(true)
+  })
+
+  it('defaults to logLevel === error', () => {
+    const { setConfig } = require('src/config')
+    const config = setConfig(getMinimalValidUserConfig())
+    expect(config).toMatchObject({
+      logLevel: 'error',
+    })
+  })
+
+  it('sets logLevel to "debug" if the URL includes the URL param tabAdsDebug=true', () => {
+    const getURL = require('src/utils/getURL').default
+    getURL.mockReturnValue(
+      'https://example.com/foo/bar/?abc=123&tabAdsDebug=true&foo'
+    )
+    const { setConfig } = require('src/config')
+    const config = setConfig({
+      ...getMinimalValidUserConfig(),
+      logLevel: 'error',
+    })
+    expect(config).toMatchObject({
+      logLevel: 'debug',
+    })
   })
 })
 

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@
 import { get } from 'lodash/object'
 import { isArray, isNil } from 'lodash/lang'
 import queue from 'src/utils/queue'
+import getURL from 'src/utils/getURL'
 import getAvailableAdUnits from 'src/getAvailableAdUnits'
 
 const newTabAdUnits = getAvailableAdUnits()
@@ -120,11 +121,29 @@ const validateConfig = (userConfig) => {
   })
 }
 
+const isDebugParamSet = () => {
+  let isDebug = false
+  try {
+    const urlStr = getURL()
+    const url = new URL(urlStr)
+    const tabAdsDebug = url.searchParams.get('tabAdsDebug')
+    isDebug = tabAdsDebug === 'true'
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e)
+  }
+  return isDebug
+}
+
 export const setConfig = (userConfig) => {
   validateConfig(userConfig)
   const fullConfig = {
     ...defaultConfig,
     ...(userConfig || {}),
+    // Override the log level if ?tabAdsDebug=true
+    logLevel: isDebugParamSet()
+      ? 'debug'
+      : userConfig.logLevel || defaultConfig.logLevel,
     consent: {
       ...defaultConfig.consent,
       ...get(userConfig, 'consent', {}),

--- a/src/providers/prebid/__tests__/prebidBidder.test.js
+++ b/src/providers/prebid/__tests__/prebidBidder.test.js
@@ -55,6 +55,34 @@ describe('prebidBidder: fetchBids', () => {
     expect(config.publisherDomain).toBeDefined()
   })
 
+  it('sets debug === false when the tab-ads logLevel is "error"', async () => {
+    expect.assertions(1)
+
+    const pbjs = getPrebidPbjs()
+    const tabAdsConfig = setConfig({
+      ...getMockTabAdsUserConfig(),
+      logLevel: 'error',
+    })
+    await prebidBidder.fetchBids(tabAdsConfig)
+
+    const config = pbjs.setConfig.mock.calls[0][0]
+    expect(config.debug).toBe(false)
+  })
+
+  it('sets debug === true when the tab-ads logLevel is "debug"', async () => {
+    expect.assertions(1)
+
+    const pbjs = getPrebidPbjs()
+    const tabAdsConfig = setConfig({
+      ...getMockTabAdsUserConfig(),
+      logLevel: 'debug',
+    })
+    await prebidBidder.fetchBids(tabAdsConfig)
+
+    const config = pbjs.setConfig.mock.calls[0][0]
+    expect(config.debug).toBe(true)
+  })
+
   it('sets the publisherDomain and pageUrl using the tab-config values', async () => {
     expect.assertions(2)
 

--- a/src/providers/prebid/prebidBidder.js
+++ b/src/providers/prebid/prebidBidder.js
@@ -296,6 +296,7 @@ const fetchBids = async (config) => {
 
     pbjs.que.push(() => {
       pbjs.setConfig({
+        debug: config.logLevel === 'debug',
         // bidderTimeout: 700 // default
         publisherDomain: config.publisher.domain, // Used for SafeFrame creative
         // Overrides the page URL adapters should use. Otherwise, some adapters

--- a/src/utils/__mocks__/getURL.js
+++ b/src/utils/__mocks__/getURL.js
@@ -1,0 +1,1 @@
+export default jest.fn(() => 'https://example.com/foo/bar/')

--- a/src/utils/__tests__/logger.test.js
+++ b/src/utils/__tests__/logger.test.js
@@ -7,7 +7,10 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-const formatMessage = (msg) => `tab-ads: ${msg}`
+const messagePrefix = [
+  '%ctab-ads',
+  'background: #4fb6ff; color: #fff; border-radius: 2px; padding: 2px 6px',
+]
 const onErrorHandler = jest.fn()
 
 beforeEach(() => {
@@ -39,7 +42,7 @@ describe('logger', () => {
     const logger = require('src/utils/logger').default
     const theMsg = 'A thing happened, FYI'
     logger.log(theMsg)
-    expect(console.log).toHaveBeenCalledWith(formatMessage(theMsg))
+    expect(console.log).toHaveBeenCalledWith(...messagePrefix, theMsg)
   })
 
   test('logger.debug logs to console', () => {
@@ -49,7 +52,7 @@ describe('logger', () => {
     const logger = require('src/utils/logger').default
     const theMsg = 'A thing happened, FYI'
     logger.debug(theMsg)
-    expect(console.debug).toHaveBeenCalledWith(formatMessage(theMsg))
+    expect(console.debug).toHaveBeenCalledWith(...messagePrefix, theMsg)
   })
 
   test('logger.info logs to console', () => {
@@ -59,7 +62,7 @@ describe('logger', () => {
     const logger = require('src/utils/logger').default
     const theMsg = 'A thing happened, FYI'
     logger.info(theMsg)
-    expect(console.info).toHaveBeenCalledWith(formatMessage(theMsg))
+    expect(console.info).toHaveBeenCalledWith(...messagePrefix, theMsg)
   })
 
   test('logger.warn logs to console', () => {
@@ -69,7 +72,7 @@ describe('logger', () => {
     const logger = require('src/utils/logger').default
     const theMsg = 'A thing happened, FYI'
     logger.warn(theMsg)
-    expect(console.warn).toHaveBeenCalledWith(formatMessage(theMsg))
+    expect(console.warn).toHaveBeenCalledWith(...messagePrefix, theMsg)
   })
 
   test('logger.error logs to console', () => {
@@ -79,7 +82,7 @@ describe('logger', () => {
     const logger = require('src/utils/logger').default
     const theMsg = 'A thing happened, FYI'
     logger.error(theMsg)
-    expect(console.error).toHaveBeenCalledWith(formatMessage(theMsg))
+    expect(console.error).toHaveBeenCalledWith(...messagePrefix, theMsg)
   })
 
   test('logger.error calls config.onError with the original message', () => {
@@ -131,7 +134,7 @@ describe('logger', () => {
     const logger = require('src/utils/logger').default
     const theMsg = 'A thing happened, FYI'
     logger.log(theMsg)
-    expect(console.log).toHaveBeenCalledWith(formatMessage(theMsg))
+    expect(console.log).toHaveBeenCalledWith(...messagePrefix, theMsg)
   })
 
   test('logger.error logs to console when the logLevel is "error"', () => {
@@ -147,7 +150,7 @@ describe('logger', () => {
     const logger = require('src/utils/logger').default
     const theMsg = 'A thing happened, FYI'
     logger.error(theMsg)
-    expect(console.error).toHaveBeenCalledWith(formatMessage(theMsg))
+    expect(console.error).toHaveBeenCalledWith(...messagePrefix, theMsg)
   })
 
   test('logger.error calls config.onError with the original message when the logLevel is "error"', () => {
@@ -217,6 +220,6 @@ describe('logger', () => {
       ...getMockTabAdsUserConfig(),
       logLevel: 'debug',
     })
-    expect(console.log).toHaveBeenCalledWith(formatMessage(theMsg))
+    expect(console.log).toHaveBeenCalledWith(...messagePrefix, theMsg)
   })
 })

--- a/src/utils/getURL.js
+++ b/src/utils/getURL.js
@@ -1,0 +1,3 @@
+const getURL = () => window.location.href
+
+export default getURL

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -29,26 +29,29 @@ const log = (msg, logLevel) => {
     if (!shouldLog(logLevel, logLevelThreshold)) {
       return
     }
-    const finalMsg = `tab-ads: ${msg}`
+    const prefix = [
+      '%ctab-ads',
+      'background: #4fb6ff; color: #fff; border-radius: 2px; padding: 2px 6px',
+    ]
     switch (logLevel) {
       case logLevels.DEBUG:
-        console.debug(finalMsg)
+        console.debug(...prefix, msg)
         break
       case logLevels.INFO:
-        console.info(finalMsg)
+        console.info(...prefix, msg)
         break
       case logLevels.LOG:
-        console.log(finalMsg)
+        console.log(...prefix, msg)
         break
       case logLevels.WARN:
-        console.warn(finalMsg)
+        console.warn(...prefix, msg)
         break
       case logLevels.ERROR:
         onError(msg)
-        console.error(finalMsg)
+        console.error(...prefix, msg)
         break
       default:
-        console.error(finalMsg)
+        console.error(...prefix, msg)
     }
   })
 }


### PR DESCRIPTION
Set the URL param `tabAdsDebug=true` on a page to enable debugging.