### PR TITLE
Update TCF settings

### DIFF
--- a/src/__tests__/ErrorBoundary.test.js
+++ b/src/__tests__/ErrorBoundary.test.js
@@ -43,7 +43,7 @@ describe('ErrorBoundary', () => {
     const { container } = render(
       <ErrorBoundary {...mockProps}>{children}</ErrorBoundary>
     )
-    expect(container).toBeEmpty()
+    expect(container).toBeEmptyDOMElement()
   })
 
   it('calls "onError" if a child throws', () => {

--- a/src/config.js
+++ b/src/config.js
@@ -38,7 +38,12 @@ const defaultConfig = {
   auctionTimeout: 1000, // Timeout for the whole auction
   bidderTimeout: 700, // Timeout of the individual bidders
   consent: {
-    timeout: 500, // Time to wait for the consent management platform (CMP) to respond
+    // Time to wait for the consent management platform (CMP) to respond.
+    // If the CMP does not respond in this time, ad auctions may be cancelled.
+    // Typically, 500ms might be too short for a CMP to load and respond.
+    // However, the tab-cmp package aims to make the CMP respond much more
+    // quickly (sub-50ms) after the user's first page load.
+    timeout: 500,
   },
   publisher: {
     domain: null, // required to be provided by user

--- a/src/config.js
+++ b/src/config.js
@@ -35,10 +35,10 @@ const defaultConfig = {
     //   sizes: [[300, 250]],
     // },
   ],
-  auctionTimeout: 1200, // Timeout for the whole auction
+  auctionTimeout: 1000, // Timeout for the whole auction
   bidderTimeout: 700, // Timeout of the individual bidders
   consent: {
-    timeout: 800, // Time to wait for the consent management platform (CMP) to respond
+    timeout: 500, // Time to wait for the consent management platform (CMP) to respond
   },
   publisher: {
     domain: null, // required to be provided by user

--- a/src/config.js
+++ b/src/config.js
@@ -35,10 +35,10 @@ const defaultConfig = {
     //   sizes: [[300, 250]],
     // },
   ],
-  auctionTimeout: 1000, // Timeout for the whole auction
+  auctionTimeout: 1200, // Timeout for the whole auction
   bidderTimeout: 700, // Timeout of the individual bidders
   consent: {
-    timeout: 200, // Time to wait for the consent management platform (CMP) to respond
+    timeout: 800, // Time to wait for the consent management platform (CMP) to respond
   },
   publisher: {
     domain: null, // required to be provided by user

--- a/src/providers/prebid/__tests__/prebidBidder.test.js
+++ b/src/providers/prebid/__tests__/prebidBidder.test.js
@@ -128,6 +128,45 @@ describe('prebidBidder: fetchBids', () => {
     ).not.toBeUndefined()
   })
 
+  it('includes the expected consentManagement GDPR settings', async () => {
+    expect.assertions(1)
+
+    const pbjs = getPrebidPbjs()
+    const tabAdsConfig = setConfig({
+      ...getMockTabAdsUserConfig(),
+      consent: {
+        timeout: 161,
+      },
+    })
+    await prebidBidder.fetchBids(tabAdsConfig)
+    expect(
+      pbjs.setConfig.mock.calls[0][0].consentManagement.gdpr
+    ).toMatchObject({
+      cmpApi: 'iab',
+      timeout: 161,
+      defaultGdprScope: false,
+    })
+  })
+
+  it('includes the expected consentManagement USP settings', async () => {
+    expect.assertions(1)
+
+    const pbjs = getPrebidPbjs()
+    const tabAdsConfig = setConfig({
+      ...getMockTabAdsUserConfig(),
+      consent: {
+        timeout: 161,
+      },
+    })
+    await prebidBidder.fetchBids(tabAdsConfig)
+    expect(pbjs.setConfig.mock.calls[0][0].consentManagement.usp).toMatchObject(
+      {
+        cmpApi: 'iab',
+        timeout: 161,
+      }
+    )
+  })
+
   it('includes the expected list of bidders for each ad', async () => {
     expect.assertions(3)
     const pbjs = getPrebidPbjs()

--- a/src/providers/prebid/prebidBidder.js
+++ b/src/providers/prebid/prebidBidder.js
@@ -304,16 +304,6 @@ const fetchBids = async (config) => {
         // Only some adapters use this setting as of May 2018.
         // https://github.com/prebid/Prebid.js/issues/1882
         pageUrl: config.publisher.pageUrl,
-        userSync: {
-          filterSettings: {
-            // EMX Digital requested iframe syncing on 13 Nov 2018 due to
-            // poor ad performance.
-            iframe: {
-              bidders: 'emx_digital',
-              filter: 'include',
-            },
-          },
-        },
         // GDPR consent.
         // http://prebid.org/dev-docs/modules/consentManagement.html
         consentManagement: {

--- a/src/providers/prebid/prebidBidder.js
+++ b/src/providers/prebid/prebidBidder.js
@@ -320,8 +320,9 @@ const fetchBids = async (config) => {
           gdpr: {
             cmpApi: 'iab',
             timeout: config.consent.timeout,
-            allowAuctionWithoutConsent: true,
-            defaultGdprScope: true,
+            // If the CMP does not respond in time, gdprApplies
+            // is false.
+            defaultGdprScope: false,
           },
           usp: {
             cmpApi: 'iab',


### PR DESCRIPTION
* Remove `allowAuctionWithoutConsent`, deprecated in TCF v2
* Change `defaultGdprScope` to false: GDPR does not apply unless in EU
* Increase default CMP timeout to 500ms
* Remove custom EMX Digital user sync settings
* Add test and update deprecated Jest method