### PR TITLE
Quick fix to disable Amazon bidder

### DIFF
--- a/src/__mocks__/getBidders.js
+++ b/src/__mocks__/getBidders.js
@@ -1,3 +1,5 @@
+// TODO: write mocks.
+
 import { isClientSide } from 'src/utils/ssr'
 
 let bidders = []
@@ -6,14 +8,10 @@ let bidders = []
 // so we can't load bidders when rendering server-side.
 if (isClientSide()) {
   const prebidBidder = require('src/providers/prebid/prebidBidder').default
-  // const amazonBidder = require('src/providers/amazon/amazonBidder').default
+  const amazonBidder = require('src/providers/amazon/amazonBidder').default
   const indexExchangeBidder = require('src/providers/indexExchange/indexExchangeBidder')
     .default
-  bidders = [
-    prebidBidder,
-    // amazonBidder,
-    indexExchangeBidder,
-  ]
+  bidders = [prebidBidder, amazonBidder, indexExchangeBidder]
 }
 
 /**

--- a/src/__tests__/fetchAds.test.js
+++ b/src/__tests__/fetchAds.test.js
@@ -16,6 +16,7 @@ jest.mock('src/providers/indexExchange/indexExchangeBidder')
 jest.mock('src/adDisplayListeners')
 jest.mock('src/google/setUpGoogleAds')
 jest.mock('src/utils/logger')
+jest.mock('src/getBidders')
 
 beforeAll(() => {
   jest.useFakeTimers()

--- a/src/__tests__/getBidders.test.js
+++ b/src/__tests__/getBidders.test.js
@@ -20,13 +20,13 @@ describe('bidders', () => {
     const { isClientSide } = require('src/utils/ssr')
     isClientSide.mockReturnValue(true)
     const prebidBidder = require('src/providers/prebid/prebidBidder').default
-    const amazonBidder = require('src/providers/amazon/amazonBidder').default
+    // const amazonBidder = require('src/providers/amazon/amazonBidder').default
     const indexExchangeBidder = require('src/providers/indexExchange/indexExchangeBidder')
       .default
     const getBidders = require('src/getBidders').default
     expect(getBidders()).toEqual([
       prebidBidder,
-      amazonBidder,
+      // amazonBidder,
       indexExchangeBidder,
     ])
   })

--- a/src/utils/__tests__/getWinningBids.js
+++ b/src/utils/__tests__/getWinningBids.js
@@ -9,6 +9,8 @@ import { getConfig, setConfig } from 'src/config'
 import BidResponse from 'src/utils/BidResponse'
 import { storeA } from 'src/utils/test-fixtures'
 
+jest.mock('src/getBidders')
+
 const getMockBidderStoredData = () => {
   const { newTabAds } = getConfig()
   return {


### PR DESCRIPTION
An Amazon-served partner is likely serving broken creative. Disabling Amazon for now.